### PR TITLE
Modify default working dir in order to be compliant to FHS

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -132,23 +132,10 @@ int Process::createWorkdir(std::string directory, bool isEncrypted) {
 	}
 
 	/* creating sidewinderd directory in user's home directory */
-	std::string workdir = pw_->pw_dir;
+	std::string workdir = "/var/lib";
 
 	if (!directory.empty()) {
 		workdir = directory;
-	}
-
-	std::string xdgData;
-
-	if (const char *env = std::getenv("XDG_DATA_HOME")) {
-		xdgData = env;
-
-		if (!xdgData.empty()) {
-			workdir = xdgData;
-		}
-	} else {
-		xdgData = "/.local/share";
-		workdir.append(xdgData);
 	}
 
 	// wait until encrypted drive becomes available
@@ -159,7 +146,11 @@ int Process::createWorkdir(std::string directory, bool isEncrypted) {
 	}
 
 	workdir.append("/sidewinderd");
+
+	privilege();
 	mkdir(workdir.c_str(), S_IRWXU);
+	chown(workdir.c_str(), pw_->pw_uid, pw_->pw_gid);
+	unprivilege();
 
 	if (chdir(workdir.c_str())) {
 		std::cerr << "Error accessing " << workdir << "." << std::endl;


### PR DESCRIPTION
As the macro configuration is common for all users, it would be better to store it in /var/lib to be compliant to Filesystem Hierarchy Standard.

Coupled with the creation of system user to launch the daemon (e.g.) :
`adduser --system --disabled-login --home /nonexistent --no-create-home --quiet sidewinderd`

This could close my issue #34

In addition, that's a better choice in order to be able to integrate package into distribution repositories like Debian's one.

I made this with my poor knowledge in C programming, hoping it could be merged.

Signed-off-by: phiwui <p_wuilleme@yahoo.fr>